### PR TITLE
Add LinkedIn post: Platform Engineers for AI Agents

### DIFF
--- a/content/posts/papermod/platform-engineer-linkedin-post/index.md
+++ b/content/posts/papermod/platform-engineer-linkedin-post/index.md
@@ -1,0 +1,64 @@
+---
+title: "Why Your Software Engineering Agent Needs You to Think Like a Platform Engineer"
+summary: "Engineers aren't disappearing. We're evolving into something bigger. From problem distillation to environment orchestration, here's what the future engineer actually does."
+date: 2025-06-18
+series: ["PaperMod"]
+weight: 3
+aliases: ["/platform-engineer-linkedin-post"]
+tags: ["AI Agents", "Platform Engineering", "Software Engineering", "LinkedIn"]
+author: ["Omer Ansari"]
+---
+
+**Target: LinkedIn**
+
+**Why Your Software Engineering Agent Needs You to Think Like a Platform Engineer**
+
+You're staring at a screen. Same as always. But something's different this time.
+
+Your AI agent just deployed a three-tier application—frontend, API, database—while you grabbed coffee. It wrote the code. Ran the tests. Fixed the bugs. Shipped it.
+
+And you're wondering: What exactly is my job now?
+
+Here's what I'm learning: **Engineers aren't disappearing. We're evolving into something bigger.**
+
+Think about it. Your AI can write a React component faster than you can. But can it distill the real problem from stakeholder chaos? Set up the guardrails? Handle the non-functional requirements? Troubleshoot when the deployment goes sideways at 2 AM?
+
+Not yet. That's where we come in.
+
+**The future engineer does five things:**
+
+**Problem distillation** - Turning messy business requirements into clean technical problems
+**Guardrails & NFR oversight** - Security, performance, compliance—the stuff that breaks products
+**Tool integration** - Wiring together the ecosystem so agents can actually work
+**Troubleshooting & reframing** - When AI gets stuck, we unstick it
+**Environment orchestration** - Designing the runtime where agents can think, build, and ship
+
+**This post? I'm pulling on that last thread.**
+
+Because here's what I've been prototyping: **Engineers as environment designers.**
+
+Remember when platform engineers served software engineers? Built the CI/CD pipelines? Managed the Kubernetes clusters? Handled the infrastructure so developers could focus on features?
+
+Yeah, that's flipping.
+
+Now you're the platform engineer. For your AI agents.
+
+You're building the scaffolding. The container orchestration. The deployment pipelines. The monitoring dashboards. The rollback strategies. All so your AI can code without breaking production.
+
+**You're not just writing code anymore. You're designing the platform where code gets written.**
+
+Your AI agent needs tooling. Observability. Service meshes. Database connections that don't timeout. APIs that respond in milliseconds, not minutes. A modular, reproducible environment where it can iterate fast without setting everything on fire.
+
+**And when it does set things on fire? You're the one with the extinguisher.**
+
+I've been building this with Dagger.io (though Docker and shell scripts work too). An AI agent runs in one container, orchestrating others. It spins up React frontends, Node.js APIs, Postgres databases—whatever the project needs. All programmatically. All reproducible.
+
+**The result? My agent can iterate on both code AND infrastructure together.**
+
+This isn't about replacing engineers. It's about **evolving us into product engineers**—directing AI agents like conductors directing an orchestra. We set the tempo. We shape the sound. We make sure everyone plays in harmony.
+
+Software engineers and product managers might merge into something new. Call them "product engineers." People who understand both the technical stack and the business problem. Who can guide AI agents toward solutions that actually ship and actually matter.
+
+*[Repo dropping soon with the full prototype and pipeline.]*
+
+**Which of these five roles feels most critical to you right now? Did I miss any? And what are you building to get better at it?**


### PR DESCRIPTION
This PR adds a new LinkedIn post discussing how software engineers are evolving into platform engineers for AI agents.

## Summary
The post explores how the role of software engineers is changing in the age of AI agents, focusing specifically on environment design and orchestration. It's written in Colin Fleming's punchy, conversational style and is optimized for LinkedIn engagement.

## Key Topics
- The evolution from code writers to environment designers
- How platform engineering roles are flipping (engineers now serve AI agents)
- Five key roles of future engineers: problem distillation, guardrails/NFR oversight, tool integration, troubleshooting, and environment orchestration
- The emergence of "product engineers" who bridge technical and business domains

## Format
- Follows Hugo/PaperMod structure consistent with existing posts
- Includes proper frontmatter with tags and metadata
- Written in Colin Fleming's direct, punchy style
- Ends with engagement question for LinkedIn discussion

The post teases an upcoming repo with a prototype demonstrating these concepts using Dagger.io for container orchestration.